### PR TITLE
fix: invisiable text in mixed sticker and text message

### DIFF
--- a/src/services/ForwardService.ts
+++ b/src/services/ForwardService.ts
@@ -161,6 +161,8 @@ export default class ForwardService {
             try {
               if (elem.type === 'image' && elem.asface
                 && !(elem.file as string).toLowerCase().endsWith('.gif')
+                // 同时存在文字消息就不作为 sticker 发送
+                && !event.message.some(it => it.type === 'text')
                 // 防止在 TG 中一起发送多个 sticker 失败
                 && event.message.filter(it => it.type === 'image').length === 1
               ) {


### PR DESCRIPTION
修正了当接收到来自qq的表情包+文字信息时，将表情包转为webp导致的文字不可见的问题