### PR TITLE
feat: support disbale forward failed message

### DIFF
--- a/src/services/ForwardService.ts
+++ b/src/services/ForwardService.ts
@@ -672,6 +672,11 @@ export default class ForwardService {
     }
     catch (e) {
       this.log.error('从 TG 到 QQ 的消息转发失败', e);
+
+      if (process.env.DISABLE_FORWARD_FAILED_MESSAGE) {
+        return;
+      }
+
       try {
         await message.reply({
           message: `<i>转发失败：${e.message}</i>\n${e}`,


### PR DESCRIPTION
有时候签名异常会一直回复发送失败，所以加上一个参数关闭这个提示
![image](https://github.com/clansty/Q2TG/assets/76520798/ee9b41f3-c274-4fb9-a81f-1d5321e93878)
