### PR TITLE
feat: don't use rich header if message contains urls

### DIFF
--- a/main/src/services/ForwardService.ts
+++ b/main/src/services/ForwardService.ts
@@ -11,7 +11,7 @@ import {
   segment,
   Sendable,
 } from 'icqq';
-import { fetchFile, getBigFaceUrl, getImageUrlByMd5 } from '../utils/urls';
+import { fetchFile, getBigFaceUrl, getImageUrlByMd5, isContainsUrl } from '../utils/urls';
 import { ButtonLike, FileLike } from 'telegram/define';
 import { getLogger, Logger } from 'log4js';
 import path from 'path';
@@ -386,7 +386,9 @@ export default class ForwardService {
       else if (files.length) {
         messageToSend.file = files;
       }
-      else if (event.message_type === 'group' && (pair.flags | this.instance.flags) & flags.RICH_HEADER && env.WEB_ENDPOINT) {
+      else if (event.message_type === 'group' && (pair.flags | this.instance.flags) & flags.RICH_HEADER && env.WEB_ENDPOINT 
+      // 当消息包含链接时不显示 RICH HEADER
+      && !isContainsUrl(message)) {
         // 没有文件时才能显示链接预览
         richHeaderUsed = true;
         // https://github.com/tdlib/td/blob/437c2d0c6e0ad104022d5ad86ddc8aedc41cb7a8/td/telegram/MessageContent.cpp#L2575

--- a/main/src/utils/urls.ts
+++ b/main/src/utils/urls.ts
@@ -32,3 +32,7 @@ export async function fetchFile(url: string): Promise<Buffer> {
 export function getAvatar(room: number | Friend | Group) {
   return fetchFile(getAvatarUrl(room));
 }
+
+export function isContainsUrl(msg: string): boolean {
+  return msg.includes("https://") || msg.includes("http://")
+}


### PR DESCRIPTION
开启 Rich Header 会导致正常链接无法被 tg 预览

简单判断当消息中包含 `https://` 或 `http://` 后跳过生成 Rich Header