### PR TITLE
fix: rich header preview fails

### DIFF
--- a/main/src/helpers/forwardHelper.ts
+++ b/main/src/helpers/forwardHelper.ts
@@ -7,7 +7,7 @@ import { ForwardMessage } from 'icqq';
 import { Api } from 'telegram';
 import { imageSize } from 'image-size';
 import env from '../models/env';
-import { md5B64 } from '../utils/hashing';
+import { md5Hex } from '../utils/hashing';
 
 const log = getLogger('ForwardHelper');
 
@@ -198,7 +198,7 @@ export default {
   generateRichHeaderUrl(apiKey: string, userId: number, messageHeader = '') {
     const url = new URL(`${env.WEB_ENDPOINT}/richHeader/${apiKey}/${userId}`);
     // 防止群名片刷新慢
-    messageHeader && url.searchParams.set('hash', md5B64(messageHeader).substring(0, 10));
+    messageHeader && url.searchParams.set('hash', md5Hex(messageHeader).substring(0, 10));
     return url.toString();
   },
 };


### PR DESCRIPTION
`base64` 会生成含有 `+` 等特殊符号的字符串，含有这些符号的 rich header 链接会被自动转义然后发送给 tg。但转义后的链接不会在 tg 里生成预览，造成 rich header 不显示以及回测失败

![图片](https://github.com/clansty/Q2TG/assets/20642596/0e04bd71-65e2-4008-8f74-b996e55b0663)

换成 `md5Hex` 可以解决这个问题
