### PR TITLE
fix: gif convert with ffmpeg

### DIFF
--- a/main/src/helpers/convert.ts
+++ b/main/src/helpers/convert.ts
@@ -35,7 +35,7 @@ const convert = {
     cachedConvert(key + '.gif', async (convertedPath) => {
       const temp = await createTempFile();
       await fsP.writeFile(temp.path, await webmData());
-      await convertWithFfmpeg(temp.path, convertedPath, 'gif', 'libvpx-vp9');
+      await convertWithFfmpeg(temp.path, convertedPath, 'gif');
       await temp.cleanup();
     }),
   tgs2gif: (key: string, tgsData: () => Promise<Buffer | Uint8Array | string>) =>


### PR DESCRIPTION
Fix h264 to gif transcoding issue by not specifying the srcFormat for gif.

```
[2025-03-09T09:39:44.704] [DEBUG] convertWithFfmpeg - 正在启动 ffmpeg: -c:v libvpx-vp9 -i /tmp/tmp-52-gJdqH6RQnF4I -y -filter_complex [0:v] palettegen=reserve_transparent=on [p]; [0:v] [p] paletteuse=dither=floyd_steinberg -f gif /app/.config/QQ/NapCat/temp/54e1ad2000000465.gif
[2025-03-09T09:39:45.782] [ERROR] convertWithFfmpeg - ffmpeg 转换失败 Error: ffmpeg exited with code 1: Error while decoding stream #0:0: Invalid data found when processing input
Cannot determine format of input stream 0:0 after EOF
Error marking filters as finished
Conversion failed!

    at ChildProcess.<anonymous> (/node_modules/.pnpm/fluent-ffmpeg@2.1.3/node_modules/fluent-ffmpeg/lib/processor.js:180:22)
    at ChildProcess.emit (node:events:524:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
```

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了 h264 到 gif 转码的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes h264 to gif transcoding issue.

</details>