### PR TITLE
fix(setup): support 6-digit telegram code

### DIFF
--- a/main/src/client/TelegramChat.ts
+++ b/main/src/client/TelegramChat.ts
@@ -60,8 +60,8 @@ export default class TelegramChat {
     return createPaginatedInlineSelector(this, message, choices);
   }
 
-  public inlineDigitInput(length: number) {
-    return inlineDigitInput(this, length);
+  public inlineDigitInput() {
+    return inlineDigitInput(this);
   }
 
   public async setProfilePhoto(photo: Buffer) {

--- a/main/src/services/SetupService.ts
+++ b/main/src/services/SetupService.ts
@@ -76,7 +76,7 @@ export default class SetupService {
         await this.informOwner(`请输入你${isCodeViaApp ? ' Telegram APP 中' : '手机上'}收到的验证码\n` +
           '👇请使用下面的按钮输入，不要在文本框输入，<b>否则验证码会发不出去并立即失效</b>',
           Button.text('👆请使用上面的按钮输入', true, true));
-        return await this.owner.inlineDigitInput(6);
+        return await this.owner.inlineDigitInput();
       },
       onError: (err) => this.log.error(err),
     });

--- a/main/src/services/SetupService.ts
+++ b/main/src/services/SetupService.ts
@@ -76,7 +76,7 @@ export default class SetupService {
         await this.informOwner(`请输入你${isCodeViaApp ? ' Telegram APP 中' : '手机上'}收到的验证码\n` +
           '👇请使用下面的按钮输入，不要在文本框输入，<b>否则验证码会发不出去并立即失效</b>',
           Button.text('👆请使用上面的按钮输入', true, true));
-        return await this.owner.inlineDigitInput(5);
+        return await this.owner.inlineDigitInput(6);
       },
       onError: (err) => this.log.error(err),
     });

--- a/main/src/utils/inlineDigitInput.ts
+++ b/main/src/utils/inlineDigitInput.ts
@@ -1,7 +1,7 @@
 import TelegramChat from '../client/TelegramChat';
 import { Button } from 'telegram/tl/custom/button';
 
-export default async function inlineDigitInput(chat: TelegramChat, length: number) {
+export default async function inlineDigitInput(chat: TelegramChat) {
   return new Promise<string>(async resolve => {
     const SYMBOL_EMPTY = '-';
     const SYMBOL_INPUT = '_';
@@ -19,17 +19,18 @@ export default async function inlineDigitInput(chat: TelegramChat, length: numbe
     }
 
     function refreshDisplay() {
-      if (input.length === length) {
-        resolve(input);
+      message.edit({
+        text: getDisplay(),
+      });
+    }
+
+    function resolveInput() {
+      resolve(input);
         message.edit({
           text: `<b>${input}</b>`,
           buttons: Button.clear(),
         });
-        return;
-      }
-      message.edit({
-        text: getDisplay(),
-      });
+      return;
     }
 
     function inputButton(digit: number | string) {
@@ -46,13 +47,18 @@ export default async function inlineDigitInput(chat: TelegramChat, length: numbe
       refreshDisplay();
     }));
 
+    const submitButton = Button.inline('提交', chat.parent.registerCallback(() => {
+      if (!input.length) return;
+      resolveInput();
+    }))
+
     const message = await chat.sendMessage({
       message: getDisplay(),
       buttons: [
         [inputButton(1), inputButton(2), inputButton(3)],
         [inputButton(4), inputButton(5), inputButton(6)],
         [inputButton(7), inputButton(8), inputButton(9)],
-        [inputButton(0), backspaceButton],
+        [inputButton(0), backspaceButton, submitButton],
       ],
     });
   });


### PR DESCRIPTION
临时试着修了下目前无法输入 6 位验证码的情况。

~~之后可能会抽时间重新兼容 5 位验证码，Soon^TM~~ 自己试着改了下，现在或许可以支持任意位数的验证码了，但受限于我的 GitHub 账号没有 icqq 包的权限没法做测试。

## Summary by Sourcery

错误修复：
- 修复在设置过程中无法输入六位数 Telegram 验证码的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inability to enter six-digit Telegram verification codes during setup.

</details>

## Summary by Sourcery

在设置过程中，通过将验证码的逐位输入与固定长度解耦，并新增显式提交动作，允许输入可变长度的 Telegram 验证码。

Bug Fixes:
- 通过移除内联数字输入界面上固定为五位数的限制，修复了在设置过程中无法输入六位数 Telegram 验证码的问题。

Enhancements:
- 更新内联数字输入界面，支持任意长度的数字输入，并使用专门的提交按钮替代在达到固定长度时的自动提交方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow variable-length Telegram verification code input during setup by decoupling digit entry from a fixed code length and adding an explicit submit action.

Bug Fixes:
- Fix inability to enter six-digit Telegram verification codes during setup by removing the fixed five-digit constraint on the inline digit input UI.

Enhancements:
- Update the inline digit input UI to support arbitrary-length numeric input with a dedicated submit button instead of auto-submitting at a fixed length.

</details>