### PR TITLE
fix(setup): 修复适配 6 位验证码没删干净的问题

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,7 @@ jobs:
     name: Publish container image
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+    permissions: write-all
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ jobs:
     name: Publish container image
     runs-on: ubuntu-latest
 
-    permissions: write-all
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +35,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GPR_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,12 @@ jobs:
     name: Publish container image
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/main/src/utils/inlineDigitInput.ts
+++ b/main/src/utils/inlineDigitInput.ts
@@ -10,10 +10,8 @@ export default async function inlineDigitInput(chat: TelegramChat) {
     let input = '';
 
     function getDisplay() {
-      const leftLength = length - input.length;
       let display = Array.from(input);
-      leftLength > 0 && display.push(SYMBOL_INPUT);
-      leftLength > 1 && display.push(...SYMBOL_EMPTY.repeat(leftLength - 1));
+      display.push(SYMBOL_INPUT);
       // 增大一点键盘的大小，方便按
       return `>>>  ${display.join(SYMBOL_SPACE)}  <<<`;
     }


### PR DESCRIPTION
~~唉我是傻逼~~

把没删干净的地方删了，然后把 workflow 发布包使用的 token 改为 PAT。

不知道为什么我这里用 `GITHUB_TOKEN` 死活没权限发布包到 registry，只好就这样了。

PAT 需要有 `write:packages` 权限。

## 由 Sourcery 总结

移除剩余的可变长度数字输入逻辑，并将 GitHub 容器注册表的身份验证切换为使用 PAT 密钥。

错误修复：
- 简化内联数字输入的显示方式，始终使用单一输入符号显示当前输入，移除对可变长度验证码的剩余处理逻辑。

CI：
- 更新 GitHub Actions 工作流，使用个人访问令牌（PAT）密钥而不是默认的 `GITHUB_TOKEN` 来对 GHCR 进行身份验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove remaining logic for variable-length digit inputs and switch GitHub container registry authentication to use a PAT secret.

Bug Fixes:
- Simplify inline digit input display to always show the current input with a single input symbol, removing leftover handling for variable-length codes.

CI:
- Update the GitHub Actions workflow to authenticate to GHCR using a personal access token secret instead of the default GITHUB_TOKEN.

</details>