### PR TITLE
fix: NapCat friend list compatibility and crash fixes

### DIFF
--- a/main/src/client/NapCatClient/client.ts
+++ b/main/src/client/NapCatClient/client.ts
@@ -216,7 +216,7 @@ export class NapCatClient extends QQClient {
         }
         category.friends.push(NapCatFriend.createExisted(this, {
           nickname: it.nick || it.nickname,
-          uid: parseInt(it.uin),
+          uid: parseInt(it.uin || it.user_id),
           remark: it.remark,
         }));
       }
@@ -225,8 +225,8 @@ export class NapCatClient extends QQClient {
     return data.map(it => ({
       name: it.categoryName || (it as any).categroyName, // typo in API
       friends: it.buddyList.map(friend => NapCatFriend.createExisted(this, {
-        nickname: friend.nick,
-        uid: parseInt(friend.uin),
+        nickname: friend.nick || friend.nickname,
+        uid: parseInt(friend.uin || friend.user_id),
         remark: friend.remark,
       })),
     }));

--- a/main/src/helpers/forwardHelper.ts
+++ b/main/src/helpers/forwardHelper.ts
@@ -241,6 +241,7 @@ export default {
   },
 
   generateRichHeaderUrl(apiKey: string, userId: number, messageHeader = '') {
+    if (!env.WEB_ENDPOINT) return '';
     const url = new URL(`${env.WEB_ENDPOINT}/richHeader/${apiKey}/${userId}`);
     // 防止群名片刷新慢
     messageHeader && url.searchParams.set('hash', md5Hex(messageHeader).substring(0, 10));

--- a/main/src/services/ConfigService.ts
+++ b/main/src/services/ConfigService.ts
@@ -74,7 +74,13 @@ export default class ConfigService {
   private async onSelectChatPersonal(entity: Friend | Group) {
     const roomId = 'uin' in entity ? entity.uin : -entity.gid;
     const name = 'uin' in entity ? entity.remark || entity.nickname : entity.name;
-    const avatar = await getAvatar(roomId);
+    let avatar: Buffer;
+    try {
+      avatar = await getAvatar(roomId);
+    }
+    catch (e) {
+      avatar = null;
+    }
     const message = await (await this.owner).sendMessage({
       message: await getAboutText(entity, true),
       buttons: [
@@ -85,7 +91,7 @@ export default class ConfigService {
           }))],
         [Button.url('手动选择现有群组', this.getAssociateLink(roomId))],
       ],
-      file: new CustomFile('avatar.png', avatar.length, '', avatar),
+      file: avatar ? new CustomFile('avatar.png', avatar.length, '', avatar) : undefined,
     });
   }
 

--- a/main/src/utils/urls.ts
+++ b/main/src/utils/urls.ts
@@ -28,6 +28,7 @@ const httpsAgent = new https.Agent({
 });
 
 export async function fetchFile(url: string): Promise<Buffer> {
+  if (!url) return Buffer.alloc(0);
   const res = await axios.get(url, {
     responseType: 'arraybuffer',
     httpsAgent,


### PR DESCRIPTION
## Summary

- NapCat API returns `user_id` instead of `uin` and `nickname` instead of `nick` in friend list responses, causing friend uin to be `NaN` and nickname to be `undefined`
- `onSelectChatPersonal` crashes when avatar loading fails (e.g. invalid uin), added try-catch like `addExact` already has
- `fetchFile` crashes on empty URL when `getAvatarUrl` returns empty string for falsy room id
- `generateRichHeaderUrl` crashes with `Invalid URL` when `WEB_ENDPOINT` is not configured, added the same guard as `generateTelegramAvatarUrl`

## Test plan

- [ ] Configure Q2TG with NapCat and verify friend list displays correct uin and nickname
- [ ] Select a friend and click "自动创建群组", verify it works without crash
- [ ] Test with `WEB_ENDPOINT` unset, verify no `Invalid URL` crash on message forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

提高 NapCat 好友处理以及相关基于 URL 的操作的健壮性和兼容性。

Bug 修复：
- 同时处理使用 `uin`/`nick` 或 `user_id`/`nickname` 的 NapCat 好友列表响应，确保好友 ID 和名称被正确解析。
- 在个人聊天选择中加载头像时，通过容忍头像获取失败并在不可用时省略该文件，防止崩溃。
- 当富文本头部或文件获取的 URL 为空，或未配置 WEB_ENDPOINT 时，提前返回以避免 `Invalid URL` 等运行时错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and compatibility of NapCat friend handling and related URL-based operations.

Bug Fixes:
- Handle NapCat friend list responses that use either `uin`/`nick` or `user_id`/`nickname` so friend IDs and names are parsed correctly.
- Prevent crashes when loading avatars in personal chat selection by tolerating avatar fetch failures and omitting the file when unavailable.
- Avoid `Invalid URL` and similar runtime errors by returning early when rich header or file fetch URLs are empty or WEB_ENDPOINT is not configured.

</details>